### PR TITLE
Add a Build Scan tag and custom value to identify the exercise

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,8 @@ gradleEnterprise {
         capture {
             isTaskInputFiles = true
         }
+        tag("dpeuni-gradle-build-cache-deep-dive-unstable-inputs")
+        value("Course", "Gradle Build Cache Deep Dive")
     }
 }
 


### PR DESCRIPTION
The tag and custom value make it easy to find all the build scans for this particular exercise in Develocity.
